### PR TITLE
collapseall/expandall in larry

### DIFF
--- a/contextmenu.js
+++ b/contextmenu.js
@@ -239,8 +239,18 @@ function rcm_foldermenu_init() {
 						targetdiv = (command == 'collapseall') ? 'expanded' : 'collapsed';
 						$("#mailboxlist div." + targetdiv).each( function() {
 							var el = $(this);
-							var matches = String($(el).attr('onclick')).match(/.*rcmail.command\(["']collapse-folder["'],\s*["']([^"']*)["']\).*/i);
-							rcmail.collapse_folder(matches[1]);
+              if ($(el).attr('onclick')) {
+                var matches = String($(el).attr('onclick')).match(/.*rcmail.command\(["']collapse-folder["'],\s*["']([^"']*)["']\).*/i);
+                rcmail.collapse_folder(matches[1]);
+              } else {
+                // larry
+                var folder = $(el).prev().attr('rel');
+                if (command == 'collapseall') {
+                  rcmail.treelist.collapse(folder);
+                } else {
+                  rcmail.treelist.expand(folder);
+                }
+              }
 						});
 						break;
 					case 'openfolder':


### PR DESCRIPTION
hi john.

i'm not sure if this applies to the classic skin as well as larry. with the roundcube-1.0 release, i see:

``` html
<li id="rcmliTGlzdHM" class="mailbox">
  <a href="./?_task=mail&amp;_mbox=Lists" onclick="return rcmail.command('list','Lists',this)" rel="Lists">Lists</a>
  <div class="treetoggle collapsed">&nbsp;</div>
...[omit]...
</li>
```

there isn't on onclick event, so the regex doesn't match anything.

also somewhat strangely, rcmail.collapse_folder() calls rcmail.treelist.toggle(), but that function doesn't exist. calling rcmail.treelist.expand() and rcmail.treelist.collapse() directly seems to work just fine.

since i'm not sure if the classic skin has the onclick attribute, the patch just falls over to this new mechanism to determine the folder name.

sorry about the tabs being spaces in the patch.

-brendan
-brendan@tucows.com
