### PR TITLE
Fix Less includes for devel mode

### DIFF
--- a/skins/elastic/contextmenu.less
+++ b/skins/elastic/contextmenu.less
@@ -2,8 +2,8 @@
  * ContextMenu plugin styles
  */
 
-@import (reference) "/skins/elastic/styles/variables";
-@import (reference) "/skins/elastic/styles/mixins";
+@import (reference) "../../../../skins/elastic/styles/variables";
+@import (reference) "../../../../skins/elastic/styles/mixins";
 
 @color-contextmenu-source-background: #f9f9f9;
 @contextmenu-placeholder-icon: "\00a0";


### PR DESCRIPTION
When running Roundcube in devel mode Less couldn't find referenced Elastic files.