### PR TITLE
Performance issue when opening a message with contextmenu and many others plugins enabled

### DIFF
--- a/contextmenu.js
+++ b/contextmenu.js
@@ -138,7 +138,7 @@ rcube_webmail.prototype.contextmenu = {
 
             var uids = null;
             $.each(rcmail.env.contextmenus, function() {
-                if ((rcmail.env.contextmenu_opening == 'beforeactivate' || $(this.container).is(':visible')) && this.menu_selection.length > 0) {
+                if (this.menu_selection.length > 0 && (rcmail.env.contextmenu_opening == 'beforeactivate' || $(this.container).is(':visible'))) {
                     uids = this.menu_selection;
                     return false;
                 }


### PR DESCRIPTION
When analyzing performances from a web browser, it would appear that the condition in "getselection" event, can be called a lot of times and then create performances issues when clicking on an item of a list (basically an email). The slow performance seems to come from the "$(this.container).is(':visible')" test which can take several milliseconds, multiplied by a lot of iterations in the loop (it probably depends on other plugins as this event is triggers every time a plugin call get_selection). Resulting that it may take a few seconds to open a message.

Most of the time "this.menu_selection.length" seem to be equal to 0, so putting the the lightest condition first brings better performance and avoid to use the poor performance "is visible" test.